### PR TITLE
Fix Date errors on European Date

### DIFF
--- a/src/main/captchaDao.ts
+++ b/src/main/captchaDao.ts
@@ -14,7 +14,7 @@ export default class CaptchaDao {
     const captcha: Captcha = {
       sitekey,
       token,
-      createdAt: new Date().toLocaleString(),
+      createdAt: new Date().toISOString().slice(0, 19).replace('T', ' '),
     };
 
     let conn: mysql.PoolConnection | undefined;


### PR DESCRIPTION
Fixed "ER_TRUNCATED_WRONG_VALUE: Incorrect datetime value" 
shouldn't  use the local date on European Dateformat, because leading to errors.
So use the hardcoded ISO String Dateformat and slice it properly for mysql